### PR TITLE
Set permissions for hostkeys

### DIFF
--- a/test/alpine/Taskfile.yml
+++ b/test/alpine/Taskfile.yml
@@ -30,6 +30,7 @@ tasks:
     desc: Start the container
     cmds:
       - chmod 600 ./root-rsa.pub ./root-ed25519.pub
+      - chmod 600 ./hostkeys/*
       - >
         docker run
         --detach

--- a/test/debian/Taskfile.yml
+++ b/test/debian/Taskfile.yml
@@ -30,6 +30,7 @@ tasks:
     desc: Start the container
     cmds:
       - chmod 600 ./root-rsa.pub ./root-ed25519.pub
+      - chmod 600 ./hostkeys/*
       - >
         docker run
         --detach

--- a/test/fedora/Taskfile.yml
+++ b/test/fedora/Taskfile.yml
@@ -30,6 +30,7 @@ tasks:
     desc: Start the container
     cmds:
       - chmod 600 ./root-rsa.pub ./root-ed25519.pub
+      - chmod 600 ./hostkeys/*
       - >
         docker run
         --detach


### PR DESCRIPTION
Hello Dominik! I have small PR:

**Problem:**
If I clone the repository, start the containers for testing (using `task test-debian:build-restart-container`, etc.), and try to run tests on my system, the `sshd` service is not started on any distribution. Upon checking the `sshd` logs on Debian, I found the following errors:

```
May 06 12:58:12 77fc7c0ef437 systemd[1]: Starting OpenBSD Secure Shell server...
May 06 12:58:12 77fc7c0ef437 sshd[60]: @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
May 06 12:58:12 77fc7c0ef437 sshd[60]: @         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
May 06 12:58:12 77fc7c0ef437 sshd[60]: @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
May 06 12:58:12 77fc7c0ef437 sshd[60]: Permissions 0644 for '/etc/ssh/keys/ssh_host_rsa_key' are too open.
May 06 12:58:12 77fc7c0ef437 sshd[60]: It is required that your private key files are NOT accessible by others.
May 06 12:58:12 77fc7c0ef437 sshd[60]: This private key will be ignored.
May 06 12:58:12 77fc7c0ef437 sshd[60]: Unable to load host key "/etc/ssh/keys/ssh_host_rsa_key": bad permissions
May 06 12:58:12 77fc7c0ef437 sshd[60]: Unable to load host key: /etc/ssh/keys/ssh_host_rsa_key
May 06 12:58:12 77fc7c0ef437 sshd[60]: @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
May 06 12:58:12 77fc7c0ef437 sshd[60]: @         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
May 06 12:58:12 77fc7c0ef437 sshd[60]: @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
May 06 12:58:12 77fc7c0ef437 sshd[60]: Permissions 0644 for '/etc/ssh/keys/ssh_host_ecdsa_key' are too open.
May 06 12:58:12 77fc7c0ef437 sshd[60]: It is required that your private key files are NOT accessible by others.
May 06 12:58:12 77fc7c0ef437 sshd[60]: This private key will be ignored.
May 06 12:58:12 77fc7c0ef437 sshd[60]: Unable to load host key "/etc/ssh/keys/ssh_host_ecdsa_key": bad permissions
May 06 12:58:12 77fc7c0ef437 sshd[60]: Unable to load host key: /etc/ssh/keys/ssh_host_ecdsa_key
May 06 12:58:12 77fc7c0ef437 sshd[60]: @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
May 06 12:58:12 77fc7c0ef437 sshd[60]: @         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
May 06 12:58:12 77fc7c0ef437 sshd[60]: @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
May 06 12:58:12 77fc7c0ef437 sshd[60]: Permissions 0644 for '/etc/ssh/keys/ssh_host_ed25519_key' are too open.
May 06 12:58:12 77fc7c0ef437 sshd[60]: It is required that your private key files are NOT accessible by others.
May 06 12:58:12 77fc7c0ef437 sshd[60]: This private key will be ignored.
May 06 12:58:12 77fc7c0ef437 sshd[60]: Unable to load host key "/etc/ssh/keys/ssh_host_ed25519_key": bad permissions
May 06 12:58:12 77fc7c0ef437 sshd[60]: Unable to load host key: /etc/ssh/keys/ssh_host_ed25519_key
May 06 12:58:12 77fc7c0ef437 sshd[60]: sshd: no hostkeys available -- exiting.
May 06 12:58:12 77fc7c0ef437 systemd[1]: ssh.service: Control process exited, code=exited, status=1/FAILURE
```

It seems like the permissions for the current `hostkeys` are not properly set.

**Solution**

Explicitly set the permissions for the host keys as required, similar to root keys, by executing the following command:
`chmod 600 ./hostkeys/*`